### PR TITLE
Fix About redirect when on about

### DIFF
--- a/app/views/about/show.html.haml
+++ b/app/views/about/show.html.haml
@@ -1,5 +1,6 @@
 .session-container
-  = image_tag "about.png"
+  = link_to root_path do
+    = image_tag "about.png"
 
   %p
     Eighty is a simple markdown note taking app. Some of its features include


### PR DESCRIPTION
Fix for about page to have redirect when clicking logo to homepage when clicking from login screen in electron #3 